### PR TITLE
feat: use new Function instead of eval

### DIFF
--- a/packages/genji-notebook/public/$genji_components/codeblock.js
+++ b/packages/genji-notebook/public/$genji_components/codeblock.js
@@ -309,7 +309,7 @@ export const Codeblock = {
     },
     async execute() {
       try {
-        const output = await eval(this.code);
+        const output = await new Function(`return ${this.code}`)();
         return Array.isArray(output) ? output : [output, null];
       } catch (e) {
         console.error(e);


### PR DESCRIPTION

```html
<script type="module">
// Not OK.
eval('number = 1'); // Throw reference error: number is not defined.
</script>
```
```html
<script type="module">
// OK.
new Function('return number = 1')();

number; // 1
</script>
```