### PR TITLE
feat(vitepress): pass Theme

### DIFF
--- a/packages/genji-theme-vitepress/__tests__/.vitepress/theme/index.js
+++ b/packages/genji-theme-vitepress/__tests__/.vitepress/theme/index.js
@@ -1,10 +1,11 @@
-import { createTheme } from "../../../src";
+import DefaultTheme from "vitepress/theme";
+import { enhanceTheme } from "../../../src";
 
 function display(fn) {
   return fn();
 }
 
-const Theme = createTheme({
+const Theme = enhanceTheme(DefaultTheme, {
   global: { display },
 });
 

--- a/packages/genji-theme-vitepress/src/Layout.vue
+++ b/packages/genji-theme-vitepress/src/Layout.vue
@@ -1,11 +1,8 @@
 <script setup>
 import { useRoute } from "vitepress";
-import DefaultTheme from "vitepress/theme";
 import { onMounted, watch, defineProps } from "vue";
 
-const { Layout } = DefaultTheme;
-
-const { global = {} } = defineProps(["global"]);
+const { global = {}, Theme } = defineProps(["global", "Theme"]);
 
 const route = useRoute();
 
@@ -39,5 +36,5 @@ function render() {
 </script>
 
 <template>
-  <Layout></Layout>
+  <Theme.Layout></Theme.Layout>
 </template>

--- a/packages/genji-theme-vitepress/src/index.js
+++ b/packages/genji-theme-vitepress/src/index.js
@@ -1,1 +1,1 @@
-export { createTheme } from "./theme";
+export { enhanceTheme } from "./theme";

--- a/packages/genji-theme-vitepress/src/theme.js
+++ b/packages/genji-theme-vitepress/src/theme.js
@@ -1,13 +1,12 @@
 import { h } from "vue";
 import Layout from "./Layout.vue";
-import DefaultTheme from "vitepress/theme";
 import "./style.css";
 
-export function createTheme({ global } = {}) {
+export function enhanceTheme(Theme, { global } = {}) {
   return {
-    extends: DefaultTheme,
+    extends: Theme,
     Layout: () => {
-      return h(Layout, { global });
+      return h(Layout, { global, Theme });
     },
   };
 }


### PR DESCRIPTION
```js
import DefaultTheme from "vitepress/theme";
import { enhanceTheme } from "../../../src";

function display(fn) {
  return fn();
}

const Theme = enhanceTheme(DefaultTheme, {
  global: { display },
});

export default {
  extends: Theme,
};
```