### PR TITLE
feat(vitepress): support hide codeblock

### DIFF
--- a/packages/genji-theme-vitepress/__tests__/markdown-extensions.md
+++ b/packages/genji-theme-vitepress/__tests__/markdown-extensions.md
@@ -38,6 +38,18 @@ It should render with `| dom` markup with `javascript`.
 block("orange");
 ```
 
+## Hide Code
+
+```js | dom "code: false"
+display(() => {
+  const div = document.createElement("div");
+  div.style.width = "100px";
+  div.style.height = "100px";
+  div.style.background = "steelblue";
+  return div;
+});
+```
+
 ## Dispose Block
 
 ```js | dom

--- a/packages/genji-theme-vitepress/src/render.js
+++ b/packages/genji-theme-vitepress/src/render.js
@@ -177,12 +177,13 @@ function render(module, { isDark }) {
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
     const { dataset } = block;
-    const { lang, parser } = dataset;
+    const { lang, parser, code: showCode } = dataset;
     const P = [parsers[lang], window[parser]].filter(Boolean);
 
     if (P.length) {
       const pre = block.getElementsByClassName("shiki")[0];
       const code = pre.textContent;
+      if (showCode === "false") block.style.display = "none";
 
       const observable = new Observable((observer) => {
         let normalized;


### PR DESCRIPTION
<img width="740" alt="image" src="https://github.com/pearmini/genji/assets/49330279/cd46550a-4996-46f5-9e5a-31f440e986d4">
