### PR TITLE
Link genji-theme-vitepress to docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "description": "The documentation for Genji",
   "scripts": {
+    "preinstall": "cd ../packages/genji-theme-vitepress && npm install",
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",
     "docs:preview": "vitepress preview"
@@ -10,7 +11,7 @@
   "author": "https://github.com/pearmini",
   "license": "MIT",
   "devDependencies": {
-    "genji-theme-vitepress": "^0.1.0",
+    "genji-theme-vitepress": "file:../packages/genji-theme-vitepress",
     "vitepress": "^1.0.0-rc.44"
   },
   "repository": {


### PR DESCRIPTION
 
<img width="739" alt="image" src="https://github.com/pearmini/genji/assets/49330279/4db002b5-c715-4f69-9762-f49bcb46b9e7">
