### PR TITLE
Props for docusaurus

### DIFF
--- a/packages/genji-theme-docusaurus/package.json
+++ b/packages/genji-theme-docusaurus/package.json
@@ -4,6 +4,10 @@
   "description": "The Docusaurus theme to enable Genji interactive Markdown extension.",
   "type": "module",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./config": "./src/config.js"
+  },
   "author": "https://github.com/pearmini",
   "license": "MIT",
   "dependencies": {

--- a/packages/genji-theme-docusaurus/src/config.js
+++ b/packages/genji-theme-docusaurus/src/config.js
@@ -1,0 +1,4 @@
+export function defineConfig(config) {
+  window.__genjiConfig = config;
+  return config;
+}

--- a/packages/genji-theme-docusaurus/src/index.js
+++ b/packages/genji-theme-docusaurus/src/index.js
@@ -1,6 +1,14 @@
 import postcssPrefixSelector from "postcss-prefix-selector";
+import path from "path";
 
-export default function genjiThemeDocusaurus(context) {
+export default function genjiThemeDocusaurus(context, options) {
+  const { siteDir } = context;
+
+  // Inject genji.config.js into clientModules.
+  context.siteConfig.clientModules.push(
+    path.resolve(siteDir, "./genji.config.js")
+  );
+
   return {
     name: "genji-theme-docusaurus",
     getThemePath() {

--- a/packages/genji-theme-docusaurus/src/theme/DocRoot/index.jsx
+++ b/packages/genji-theme-docusaurus/src/theme/DocRoot/index.jsx
@@ -8,7 +8,8 @@ export default function DocRoot(props) {
   const location = useLocation();
 
   useEffect(() => {
-    if (!pageRef.current) pageRef.current = new Page();
+    const config = window.__genjiConfig || {};
+    if (!pageRef.current) pageRef.current = new Page(config);
     pageRef.current.render();
     return () => pageRef.current.dispose();
   }, [location.pathname]);

--- a/packages/genji-theme-docusaurus/test/docs/block2.md
+++ b/packages/genji-theme-docusaurus/test/docs/block2.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 1
+---
+
+# Block2
+
+```js eval
+block("steelblue");
+```

--- a/packages/genji-theme-docusaurus/test/docusaurus.config.js
+++ b/packages/genji-theme-docusaurus/test/docusaurus.config.js
@@ -34,7 +34,7 @@ const config = {
     locales: ["en"],
   },
 
-  plugins: ["../src/"],
+  plugins: ["genji-theme-docusaurus"],
 
   presets: [
     [

--- a/packages/genji-theme-docusaurus/test/genji.config.js
+++ b/packages/genji-theme-docusaurus/test/genji.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "genji-theme-docusaurus/config";
+
+export default defineConfig({
+  library: {
+    block: (color) => {
+      const div = document.createElement("div");
+      div.style.width = "100px";
+      div.style.height = "100px";
+      div.style.background = color;
+      return div;
+    },
+  },
+});

--- a/packages/genji-theme-docusaurus/test/package.json
+++ b/packages/genji-theme-docusaurus/test/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "3.3.2",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.1",
+    "genji-theme-docusaurus": "^0.2.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      genji-theme-docusaurus:
+        specifier: ^0.2.0
+        version: link:..
       prism-react-renderer:
         specifier: ^2.3.1
         version: 2.3.1(react@18.3.1)


### PR DESCRIPTION
- create 'genji.config.js'
- add globals:

```js
// genji.config.js

import { defineConfig } from "../src/config";

export default defineConfig({
  library: {
    block: (color) => {
      const div = document.createElement("div");
      div.style.width = "100px";
      div.style.height = "100px";
      div.style.background = color;
      return div;
    },
  },
});
```